### PR TITLE
Updated regional assessment approach

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReefGuide"
 uuid = "cee0a5fb-9790-4c4c-b8b7-e40ecbebeb72"
 authors = ["Takuya Iwanaga", "Benjamin Grier", "Arlo White", "Peter Baker"]
-version = "0.1.6"
+version = "0.1.8"
 
 [deps]
 ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"

--- a/src/ReefGuide.jl
+++ b/src/ReefGuide.jl
@@ -40,7 +40,8 @@ export initialize_data,
 @setup_workload begin
     @compile_workload begin
         # Enforce precompilation of specific geospatial read/write methods
-        GeoParquet.read(joinpath(pkgdir(ReefGuide), "assets", "dummy.parq"))
+        tmp_parq = GeoParquet.read(joinpath(pkgdir(ReefGuide), "assets", "dummy.parq"))
+        Base.summarysize(tmp_parq)
         GDF.read(joinpath(pkgdir(ReefGuide), "assets", "dummy.gpkg"))
 
         tmpfile = tempname()

--- a/src/assessment_methods/best_fit_polygons.jl
+++ b/src/assessment_methods/best_fit_polygons.jl
@@ -244,7 +244,7 @@ function find_optimal_site_alignment(
 
         # If there are a group of pixels close to each other, only assess the one closest to
         # the center of the group.
-        idx, dists = knn(kdtree, coords, 60)  # retrieve 60 closest locations
+        idx, dists = knn(kdtree, coords, 30)  # retrieve 30 closest locations
 
         # Select current pixel and those ~50% of max shape length away
         x_d = meters_to_degrees(x_dist, coords[2])

--- a/src/assessment_methods/best_fit_polygons.jl
+++ b/src/assessment_methods/best_fit_polygons.jl
@@ -423,12 +423,16 @@ function assess_location_quality(
 
     max_count = floor(Int64, (x_dist * y_dist) / res^2)
 
-    # Create search tree
-    @debug "Generating STRT tree"
-    @time tree = STRT.STRtree(lookup_tbl.geometry)
     assessment_locs = lookup_tbl[assessment_idx, :]
+
+    # Create tree specific to search area
+    time_taken = @elapsed begin
+        tree = STRT.STRtree(assessment_locs.geometry)
+    end
+    @debug "Took $(time_taken) seconds to create search-specific tree"
+
     n_pixels_to_assess = nrow(assessment_locs)
-    results = zeros(Int8, n_pixels_to_assess)  # Percent value 0 -100
+    results = zeros(Int8, n_pixels_to_assess)  # Percent value 0 - 100
 
     @debug "$(now()) : Assessment start"
     @time Threads.@threads for i in 1:n_pixels_to_assess

--- a/src/assessment_methods/best_fit_polygons.jl
+++ b/src/assessment_methods/best_fit_polygons.jl
@@ -413,11 +413,11 @@ function assess_location_quality(
     res = degrees_to_meters(res, lookup_tbl.lats[1])
     x_dist = ceil(Int64, res * 3)  # Search area immediate around target pixel
     y_dist = x_dist
-    @debug "Initial search box: $(x_dist)m * $(y_dist)m with res: $(res)m^2"
-    @time search_box = initial_search_box(
+    @debug "Initial search box: $(x_dist)m * $(y_dist)m with res: $(round(res; digits=2))m^2"
+    search_box = initial_search_box(
         (lookup_tbl.lons[1], lookup_tbl.lats[1]),
-        x_dist,
-        y_dist,
+        x_dist * 0.75, # Approach uses the "touches" algorithm to select pixels so reduce
+        y_dist * 0.75, # size of polygon to ensure only relevant pixels are "touched"
         target_crs
     )
 
@@ -463,7 +463,7 @@ function assess_location_quality(
     end
 
     # Cap to 0 - 100
-    clamp!(results, Int8(0), Int8(100))
+    results = clamp!(results, Int8(0), Int8(100))
 
     return results
 end

--- a/src/assessment_methods/site_identification.jl
+++ b/src/assessment_methods/site_identification.jl
@@ -105,7 +105,7 @@ end
 Perform raster suitability assessment based on user-defined criteria.
 
 # Arguments
-- params :: RegionalAssessmentParameters
+- `params` : RegionalAssessmentParameters
 
 # Returns
 Raster indicating suitability of target pixel and immediate surrounds.

--- a/src/assessment_methods/site_identification.jl
+++ b/src/assessment_methods/site_identification.jl
@@ -3,7 +3,7 @@
 """
     proportion_suitable(
         x::Union{BitMatrix,SparseMatrixCSC{Bool,Int64}}; square_offset::Tuple=(-4, 5)
-    )::SparseMatrixCSC{UInt8,Int64}
+    )::SparseMatrixCSC{Int8,Int64}
 
 Calculate the the proportion of the subsection that is suitable for deployments.
 The `subsection` is the surrounding a rough hectare area centred on each cell of a raster
@@ -26,9 +26,9 @@ meet suitability criteria.
 """
 function proportion_suitable(
     x::Union{BitMatrix,SparseMatrixCSC{Bool,Int64}}; square_offset::Tuple=(-4, 5)
-)::SparseMatrixCSC{UInt8,Int64}
+)::SparseMatrixCSC{Int8,Int64}
     subsection_dims = size(x)
-    target_area = spzeros(UInt8, subsection_dims)
+    target_area = spzeros(Int8, subsection_dims)
 
     for row_col in findall(x)
         (row, col) = Tuple(row_col)
@@ -38,7 +38,7 @@ function proportion_suitable(
         y_top = max(row + square_offset[1], 1)
         y_bottom = min(row + square_offset[2], subsection_dims[1])
 
-        target_area[row, col] = UInt8(sum(@views x[y_top:y_bottom, x_left:x_right]))
+        target_area[row, col] = Int8(sum(@views x[y_top:y_bottom, x_left:x_right]))
     end
 
     return target_area
@@ -82,7 +82,7 @@ function assess_region(
             indicator[r.lon_idx, r.lat_idx] = true
         end
     else
-        @debug "$(now()) : Creating mask as a sparse matrix (est. size: $(mask_size_MB))"
+        @debug "$(now()) : Creating mask as a sparse matrix (est. full size: $(mask_size_MB))"
 
         valid_lons = lookup_tbl[matching_idx, :lon_idx]
         valid_lats = lookup_tbl[matching_idx, :lat_idx]
@@ -149,7 +149,7 @@ function assess_region_quality(
             indicator[r.lon_idx, r.lat_idx] = quality_indicator[i]
         end
     else
-        @debug "$(now()) : Creating mask as a sparse matrix (est. size: $(mask_size_MB))"
+        @debug "$(now()) : Creating mask as a sparse matrix (est. full size: $(mask_size_MB))"
 
         valid_lons = lookup_tbl[matching_idx, :lon_idx]
         valid_lats = lookup_tbl[matching_idx, :lat_idx]

--- a/src/utility/file_io.jl
+++ b/src/utility/file_io.jl
@@ -22,8 +22,11 @@ function _write_cog(
         driver="COG",
         options=Dict{String,String}(
             "COMPRESS" => "DEFLATE",
+            "LEVEL" => "1",
+            "PREDICTOR" => "YES",
             "SPARSE_OK" => "TRUE",
             "OVERVIEW_COUNT" => "5",
+            "BIGTIFF" => "IF_SAFER",
             "BLOCKSIZE" => string(first(tile_size)),
             "NUM_THREADS" => string(num_threads)
         ),

--- a/src/utility/regions_criteria_setup.jl
+++ b/src/utility/regions_criteria_setup.jl
@@ -230,7 +230,8 @@ corresponding layer in the RasterStack
 # Fields
 - `region_id::String` : Unique identifier for the region
 - `region_metadata::RegionMetadata` : Display metadata for the region
-- `raster_stack::Rasters.RasterStack` : Geospatial raster data layers
+- `res::Float64` : Resolution of raster data set used for region
+- `crs::EPSG` : Coordinate Reference System
 - `slope_table::DataFrame` : Coordinates and values for valid slope reef
   locations
 - `criteria::Dict{String, BoundedCriteria}` : Computed criteria bounds for this region
@@ -239,7 +240,8 @@ struct RegionalDataEntry
     region_id::String
     region_metadata::RegionMetadata
     valid_extent::Rasters.Raster
-    raster_stack::Rasters.RasterStack
+    res::Float64
+    crs::EPSG
     slope_table::DataFrame
     criteria::BoundedCriteriaDict
 
@@ -328,8 +330,10 @@ struct RegionalDataEntry
             instantiated_criteria
         ) expected_criteria = length(expected_criteria_set)
 
+        res = abs(step(dims(raster_stack, X)))
+        epsg_code = convert(EPSG, crs(raster_stack))
         return new(
-            region_id, region_metadata, valid_extent, raster_stack, slope_table, criteria
+            region_id, region_metadata, valid_extent, res, epsg_code, slope_table, criteria
         )
     end
 end
@@ -655,7 +659,9 @@ function initialize_data(data_source_directory::String)::RegionalData
 end
 
 # standard English
-@deprecate initialise_data(data_source_directory::String) initialize_data(data_source_directory)
+@deprecate initialise_data(data_source_directory::String) initialize_data(
+    data_source_directory
+)
 
 # =============================================================================
 # Display Methods

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -9,6 +9,7 @@ using
     Interpolations
 
 import GeoDataFrames as GDF
+import SortTileRecursiveTree as STRT
 
 include("types.jl")
 include("regions_criteria_setup.jl")


### PR DESCRIPTION
Now returns an indication of pixel quality according to suitability towards the different criteria.

Counts the number of pixels in a given "box" that meet all criteria and scores it out of 100 (percent) 

i.e., nominally 9/9 pixels == 100%, although some deviation can occur due to polygons and pixels not completely lining up, leading to more than expected pixels being selected.

Approach now uses the lookup tables and a more efficient approach of creating sparse rasters. Assessment times are now ~1min locally.