### PR TITLE
Update README.md - depth data spec description table

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For detailed scientific methodology and parameter guidance, consult with the pro
 | ----------------------- | ---------- | ----------------------------------- | ------------------------ | ----------------------------------------------------------------------------- |
 | **Slope Lookup Table**  | Parquet    | `{region}_valid_slopes_lookup.parq` | All (4 files)            | Point data with coordinates and environmental values for valid reef locations |
 | **Valid Extent Raster** | GeoTIFF    | `{region}_valid_slopes.tif`         | All (4 files)            | Binary mask indicating valid reef slope areas                                 |
-| **Depth Raster**        | GeoTIFF    | `{region}*_bathy.tif`               | All (4 files)            | Bathymetry data (corrected to Mean Sea Level)                                 |
+| **Depth Raster**        | GeoTIFF    | `{region}*_bathy.tif`               | All (4 files)            | Bathymetry data (metres, where depth is represented in negative numbers       |
 | **Slope Raster**        | GeoTIFF    | `{region}*_slope.tif`               | All (4 files)            | Reef slope angles in degrees                                                  |
 | **Turbidity Raster**    | GeoTIFF    | `{region}*_turbid.tif`              | All (4 files)            | Water clarity (Secchi depth in meters)                                        |
 | **Wave Height Raster**  | GeoTIFF    | `{region}*_waves_Hs.tif`            | All (4 files)            | Significant wave height, 90th percentile (meters)                             |


### PR DESCRIPTION
updated summary table of data spec
-if the summary table is mean to be applicable to any inputs, the fact that the GBR data (EOMAP SDB bathymetry) is corrected to mean sea level isn't relevant here (it should be listed elsewhere in other data input descriptions, relevant to the sample data)

-the fact that depth is in metres, and in negative numbers is a data spec though